### PR TITLE
⚡ Bolt: Precompute regexes in resolveChainFromText

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-11 - Precompute regexes and sorting on module load
+**Learning:** The `resolveChainFromText` function was unnecessarily sorting aliases and recompiling regexes on every call. This introduced O(N log N) overhead and regex compilation latency in a hot path.
+**Action:** Always precalculate and cache heavy operations like regex compilation and array sorting at module load time for text processing utilities.

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -82,15 +82,23 @@ export function resolveChain(input?: string | null): ChainInfo | undefined {
   return ALIAS_MAP[key];
 }
 
+// Precompute sorted aliases and regular expressions to avoid O(N log N) sorting
+// and regex recompilation on every `resolveChainFromText` call.
+const SORTED_ALIASES = Object.keys(ALIAS_MAP).sort((a, b) => b.length - a.length);
+const ALIAS_REGEXES = SORTED_ALIASES.map(alias => {
+  const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return {
+    alias,
+    re: new RegExp(`(?:^|[^a-z0-9_])(${escaped})(?:$|[^a-z0-9_])`, "i"),
+  };
+});
+
 // Tries to find a chain mention anywhere in a free-text sentence
 export function resolveChainFromText(text?: string | null): ChainInfo | undefined {
   if (!text) return undefined;
   const lower = text.toLowerCase();
   // Prioritize longer aliases first to avoid mis-matches (e.g., "op" in words)
-  const all = Object.keys(ALIAS_MAP).sort((a, b) => b.length - a.length);
-  for (const alias of all) {
-    const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const re = new RegExp(`(?:^|[^a-z0-9_])(${escaped})(?:$|[^a-z0-9_])`, "i");
+  for (const { alias, re } of ALIAS_REGEXES) {
     if (re.test(lower)) return ALIAS_MAP[alias];
   }
   return undefined;


### PR DESCRIPTION
💡 What: Extract sorted aliases and precompile regexes to module scope.
🎯 Why: `resolveChainFromText` was executing O(N log N) sorting and RegExp compilation on every single invocation.
📊 Impact: Removes redundant O(N log N) array sorting and expensive dynamic RegExp compilation from the function call execution path.
🧪 Measurement: Verified by running `bun test ./src/lib/chains.ts` and standard test suites.

---
*PR created automatically by Jules for task [3572724109819500220](https://jules.google.com/task/3572724109819500220) started by @programmeradu*