### PR TITLE
🛡️ Sentinel: [HIGH] Fix open redirect vulnerability in auth redirect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - [Open Redirect in Auth Redirect]
+**Vulnerability:** Found an open redirect vulnerability in `src/app/auth/page.tsx` where `searchParams.get('redirect')` was directly assigned to `window.location.href`.
+**Learning:** `searchParams.get()` input is untrusted and must be sanitized. If not validated, an attacker can construct a URL like `?redirect=https://malicious.site`, resulting in an open redirect after auth.
+**Prevention:** Always validate and sanitize the input to prevent Open Redirect vulnerabilities. Ensure the URL is a relative path starting with `/` and not an absolute or protocol-relative URL (e.g., `redirect.startsWith('/') && !redirect.startsWith('//')`) before assigning it to `window.location.href` or using it for a redirect.

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -525,7 +525,10 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const rawRedirect = searchParams.get('redirect');
+    const postAuthRedirect = rawRedirect && rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+        ? rawRedirect
+        : '/app';
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was vulnerable to an Open Redirect. The `redirect` query parameter from the URL was being directly extracted and assigned to `window.location.href` without validation.
🎯 **Impact:** An attacker could craft a malicious link like `https://.../auth?redirect=https://evil.com`. Once the user authenticates, they would be immediately redirected to the malicious site, potentially leading to phishing or session token leakage.
🔧 **Fix:** Added validation to the `redirect` parameter to ensure it is a relative path starting with `/` and not a protocol-relative path starting with `//`. If validation fails, it safely falls back to `/app`.
✅ **Verification:** Ran Next.js tests, manual verification, and confirmed via local node script that absolute/protocol-relative URLs are rejected.

---
*PR created automatically by Jules for task [16817227291471283254](https://jules.google.com/task/16817227291471283254) started by @programmeradu*