### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in authentication flows

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-23 - Open Redirect Fix
+
+**Vulnerability:** Open Redirect
+**Learning:** Found an Open Redirect via URL search parameters in `src/app/auth/page.tsx` and `src/app/api/auth/callback/route.ts` because it blindly accepted `//evil.com`.
+**Prevention:** Explicitly validate URL query parameters starting with `/` to ensure they are relative paths, and importantly, ensure they do not start with `//` to avoid protocol-relative absolute URLs.

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -15,7 +15,8 @@ import { eq } from 'drizzle-orm';
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const rawNext = searchParams.get('next');
+    const next = (rawNext && rawNext.startsWith('/') && !rawNext.startsWith('//')) ? rawNext : '/app';
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -525,7 +525,10 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const rawRedirect = searchParams.get('redirect');
+    const postAuthRedirect = (rawRedirect && rawRedirect.startsWith('/') && !rawRedirect.startsWith('//'))
+        ? rawRedirect
+        : '/app';
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Open Redirect vulnerability in the authentication callback and UI routes. The `next` and `redirect` search parameters were not correctly validated, allowing protocol-relative URLs (`//evil.com`) to be used to silently redirect users to external domains upon successful sign-in.
🎯 Impact: Attackers could craft malicious links leading to phishing sites, tricking users who are expecting to be redirected back to the legitimate application after signing in.
🔧 Fix: Validated that the redirect URLs must start with exactly one `/` and not start with `//`. If validation fails, it defaults to `/app`.
✅ Verification: Tested via a simulated script and manually verified logic. Reviewed that `//malicious.com` resolves to `/app` instead.

---
*PR created automatically by Jules for task [5096245511862651030](https://jules.google.com/task/5096245511862651030) started by @programmeradu*