### PR TITLE
⚡ Bolt: [performance improvement] Memoize ExecutionHistory lists and components

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Memoize `filteredExecutions` and `sortedExecutions` in `src/components/ExecutionHistory.tsx`**
+   - The current implementation recalculates `filteredExecutions` and `sortedExecutions` on every render, which involves filtering and sorting potentially large arrays.
+   - We will use `useMemo` to memoize these calculations, depending only on `executions`, `filter`, and `sortBy`.
+
+2. **Memoize the `ExecutionRow` component in `src/components/ExecutionHistory.tsx`**
+   - The `ExecutionRow` component can be wrapped in `React.memo` to avoid re-rendering rows that haven't changed.
+
+3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run tests, check formatting, etc.
+
+4. **Submit a PR as Bolt with the title "⚡ Bolt: [performance improvement]".**

--- a/src/components/ExecutionHistory.tsx
+++ b/src/components/ExecutionHistory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect , useMemo, memo } from "react";
 import { ExecutionStatus } from "@/lib/agents/types";
 import { formatDistanceToNow } from "date-fns";
 
@@ -81,16 +81,20 @@ export function ExecutionHistory({
     }
   };
 
-  const filteredExecutions = filter
-    ? executions.filter((e) => e.strategy === filter || e.status === filter)
-    : executions;
+  const filteredExecutions = useMemo(() => {
+    return filter
+      ? executions.filter((e) => e.strategy === filter || e.status === filter)
+      : executions;
+  }, [executions, filter]);
 
-  const sortedExecutions = [...filteredExecutions].sort((a, b) => {
-    if (sortBy === "newest") {
-      return b.createdAt - a.createdAt;
-    }
-    return a.createdAt - b.createdAt;
-  });
+  const sortedExecutions = useMemo(() => {
+    return [...filteredExecutions].sort((a, b) => {
+      if (sortBy === "newest") {
+        return b.createdAt - a.createdAt;
+      }
+      return a.createdAt - b.createdAt;
+    });
+  }, [filteredExecutions, sortBy]);
 
   if (compact) {
     return (
@@ -194,7 +198,7 @@ export function ExecutionHistory({
 /**
  * Individual execution row component
  */
-function ExecutionRow({ execution }: { execution: Execution }) {
+const ExecutionRow = memo(function ExecutionRow({ execution }: { execution: Execution }) {
   const [expanded, setExpanded] = useState(false);
 
   const statusColor =
@@ -252,7 +256,7 @@ function ExecutionRow({ execution }: { execution: Execution }) {
       )}
     </div>
   );
-}
+});
 
 /**
  * Execution details component


### PR DESCRIPTION
💡 **What:** Wrapped `filteredExecutions` and `sortedExecutions` with `useMemo` to prevent redundant array iterations and sorting operations on every render. Additionally, wrapped `ExecutionRow` component with `React.memo()` to skip re-renders for rows whose props haven't changed.
🎯 **Why:** Arrays of execution history can grow large, causing expensive `O(n log n)` sort recalculations whenever the component updates (e.g., due to local state changes like refreshing). `ExecutionRow` components also map over this array and unnecessarily re-render on every list update, causing DOM painting overhead.
📊 **Impact:** Reduces React render cycle times by avoiding unnecessary Array `.filter()` and `.sort()`. Eliminates unnecessary component tree reconciliation for existing list items.
🔬 **Measurement:** Use React DevTools Profiler to compare component render durations for `ExecutionHistory` and observe that `ExecutionRow` components no longer re-render when the parent updates (except for new items).

---
*PR created automatically by Jules for task [15407918332882024925](https://jules.google.com/task/15407918332882024925) started by @programmeradu*