### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in authentication routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Open Redirect in Authentication Flow
+**Vulnerability:** Found an Open Redirect vulnerability where authentication callbacks and pages consumed user-supplied `?redirect=` and `?next=` parameters verbatim and passed them to `window.location.href = ...` or `NextResponse.redirect(...)`.
+**Learning:** In Next.js client and server components, query parameters extracted via `searchParams.get(...)` are un-sanitized. Assigning them directly to `window.location.href` or passing them to routing frameworks enables arbitrary URL redirection.
+**Prevention:** Always validate user-supplied redirect URLs to ensure they are relative paths by checking `url.startsWith('/') && !url.startsWith('//')` before redirection.

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -15,7 +15,8 @@ import { eq } from 'drizzle-orm';
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const rawNext = searchParams.get('next') ?? '/app';
+    const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/app';
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -525,7 +525,8 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const rawRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//') ? rawRedirect : '/app';
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: An Open Redirect vulnerability existed in `src/app/auth/page.tsx` and `src/app/api/auth/callback/route.ts` where user-supplied `?redirect=` and `?next=` parameters were assigned to `window.location.href` and `NextResponse.redirect()` without validation.
🎯 **Impact**: Attackers could craft links like `?redirect=//evil.com` to phish users after successful authentication.
🔧 **Fix**: Added validation to ensure the parsed redirect strings start with a single `/` and not `//` before performing the redirect, defaulting safely to `/app`.
✅ **Verification**:
- Validated via `bun test` and verified builds.
- Added a Sentinel journal entry reflecting the learnings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15681371711120892491](https://jules.google.com/task/15681371711120892491) started by @programmeradu*