### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect vulnerability in auth flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Open Redirect via Unsanitized Next Parameter
+**Vulnerability:** The application was directly using user-supplied URLs from `?next=` or `?redirect=` query parameters in `NextResponse.redirect()` and `window.location.href` (e.g., in `src/app/api/auth/callback/route.ts` and `src/app/auth/page.tsx`).
+**Learning:** These parameters were not validated to ensure they were relative paths. An attacker could craft a malicious URL (e.g., `https://myapp.com/auth?redirect=//evil.com`) which would successfully authenticate the user and then seamlessly redirect them to an external, attacker-controlled site.
+**Prevention:** Always validate and sanitize user-supplied redirect URLs before using them. A centralized `sanitizeRedirect` utility should enforce that the URL is a relative path starting with `/` and reject protocol-relative URLs (`//`) and path traversal attempts (`/\`).

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -11,11 +11,12 @@ import { createSupabaseServerClient } from '@/lib/supabase';
 import { db } from '@/db';
 import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { sanitizeRedirect } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const next = sanitizeRedirect(searchParams.get('next'), '/app');
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -6,6 +6,7 @@ import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { useKeystoneAuth } from "@/hooks/useKeystoneAuth";
 import { useRouter, useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { sanitizeRedirect } from "@/lib/utils";
 import {
     Shield,
     Wallet,
@@ -414,7 +415,7 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = sanitizeRedirect(searchParams.get('redirect'), '/app');
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+
+export function sanitizeRedirect(url: string | null, fallback: string = '/app'): string {
+  if (!url) return fallback;
+  // Ensure the URL is a relative path starting with /
+  // Reject protocol-relative URLs (//) and path traversal attempts (/\)
+  if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/\\')) {
+    return url;
+  }
+  return fallback;
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application used user-supplied URLs from `?next=` and `?redirect=` query parameters directly in redirects without validating them as relative paths, exposing an Open Redirect vulnerability.
🎯 Impact: Attackers could craft links to deceive users into authenticating and then redirect them to external malicious sites, facilitating phishing attacks or token theft.
🔧 Fix: Introduced a centralized `sanitizeRedirect` utility in `src/lib/utils.ts` to ensure redirect URLs are relative paths starting with `/` and rejecting `//` or `/\`. Applied this utility in `src/app/api/auth/callback/route.ts` and `src/app/auth/page.tsx`.
✅ Verification: Tested against `//evil.com` and `/\\evil.com` to confirm they fallback to `/app`. Ran the test suite, linter, and build tools to ensure no regressions. Included a Sentinel journal entry.

---
*PR created automatically by Jules for task [10772662921385709220](https://jules.google.com/task/10772662921385709220) started by @programmeradu*