### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Open Redirect Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-23 - Open Redirect Vulnerability
+**Vulnerability:** Open Redirect vulnerability where `searchParams.get('redirect')` was directly assigned to `window.location.href` without sanitization.
+**Learning:** Query parameters must not be trusted and directly fed to client-side navigation functions, as attackers can craft phishing links bypassing local domain limitations.
+**Prevention:** Use a centralized utility like `sanitizeRedirect` to ensure redirect URLs are strictly relative paths starting with `/` and not `//` or `/\`.

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -6,6 +6,7 @@ import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { useKeystoneAuth } from "@/hooks/useKeystoneAuth";
 import { useRouter, useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { sanitizeRedirect } from "@/lib/utils";
 import {
     Shield,
     Wallet,
@@ -414,7 +415,7 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = sanitizeRedirect(searchParams.get('redirect'));
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function sanitizeRedirect(url: string | null | undefined, fallback: string = '/app'): string {
+    if (!url) return fallback;
+
+    // Ensure it's a relative path starting with /
+    // Block protocol-relative URLs (//) and backslash tricks (/\)
+    if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/\\')) {
+        return url;
+    }
+
+    return fallback;
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Open Redirect vulnerability where `searchParams.get('redirect')` was directly assigned to `window.location.href` without sanitization. This allowed attackers to craft malicious links bypassing the local domain constraint.
🎯 Impact: Attackers could send users phishing links that redirect them to malicious sites after authentication, leading to potential credential theft or further exploitation.
🔧 Fix: Created a `sanitizeRedirect` utility function in `src/lib/utils.ts` and used it in `src/app/auth/page.tsx` to enforce that redirects must be relative paths starting with a forward slash.
✅ Verification: Ran TypeScript compilation and verified the fix was applied to `src/app/auth/page.tsx`. Verified the format of `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [933060429988171198](https://jules.google.com/task/933060429988171198) started by @programmeradu*