### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect vulnerability in authentication flows

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Open Redirect Vulnerability
+**Vulnerability:** URL redirect parameters (e.g., `?redirect=` or `?next=`) were being used directly to set `window.location.href` or `NextResponse.redirect()` without validation.
+**Learning:** This can lead to Open Redirect attacks, where attackers trick users into visiting a legitimate site that then automatically redirects them to a malicious site.
+**Prevention:** Always validate and sanitize user-provided redirect URLs. Ensure the URL is a relative path (starts with `/` and not `//` or `/\`) using a shared utility function like `sanitizeRedirect` before using it in any redirection logic.

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -11,11 +11,12 @@ import { createSupabaseServerClient } from '@/lib/supabase';
 import { db } from '@/db';
 import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { sanitizeRedirect } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const next = sanitizeRedirect(searchParams.get('next'), '/app');
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -22,6 +22,7 @@ import { DreyvMark } from "@/components/brand/dreyv-mark";
 import { DreyvLogoLight } from "@/components/brand/dreyv-logo-light";
 import { motion, AnimatePresence } from "framer-motion";
 import { marketingPrimaryCta } from "@/components/home/marketing-styles";
+import { sanitizeRedirect } from "@/lib/utils";
 
 const LOGO_DEV_TOKEN = "pk_DFEjHHL4QteaMOzcFuSlwg";
 
@@ -414,7 +415,7 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = sanitizeRedirect(searchParams.get('redirect'), '/app');
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function sanitizeRedirect(url: string | null | undefined, fallback: string = '/app'): string {
+  if (!url || typeof url !== 'string') return fallback;
+  // Validates if it is a relative URL starting with / and not // or /\ to prevent open redirect
+  if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/\\')) {
+    return url;
+  }
+  return fallback;
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: URL redirect parameters (`?redirect=` and `?next=`) were being passed directly to `window.location.href` and `NextResponse.redirect()` without validation, enabling Open Redirect attacks.
🎯 Impact: Attackers could craft malicious links that appear legitimate (e.g., `dreyv.com/auth?redirect=//evil.com`) to steal user credentials or distribute malware after successful authentication.
🔧 Fix: Added a `sanitizeRedirect` utility in `src/lib/utils.ts` that enforces relative paths (starting with `/` and avoiding protocol-relative `//` or `/\`). Applied this sanitization to `src/app/auth/page.tsx` and `src/app/api/auth/callback/route.ts`.
✅ Verification: Ran `bun run lint` and `bun x tsc` locally to ensure no typing regressions. Verified that `sanitizeRedirect` correctly falls back to `/app` for invalid payloads.

---
*PR created automatically by Jules for task [13644152022962897088](https://jules.google.com/task/13644152022962897088) started by @programmeradu*