### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect vulnerability in auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-30 - Open Redirect Vulnerability in Authentication Flow
+**Vulnerability:** Open redirect allowing attackers to redirect users to malicious domains after authentication via the `redirect` and `next` query parameters.
+**Learning:** Raw query parameters like `searchParams.get('redirect')` were assigned directly to `window.location.href` and `NextResponse.redirect()` without validation, bypassing same-origin security.
+**Prevention:** Always sanitize redirect URLs sourced from user input (like query parameters). Use a centralized utility like `sanitizeRedirect` to ensure the URL is a relative path (starts with `/` but not `//` or `/\`) before using it in redirects.

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -11,11 +11,12 @@ import { createSupabaseServerClient } from '@/lib/supabase';
 import { db } from '@/db';
 import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { sanitizeRedirect } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const next = sanitizeRedirect(searchParams.get('next'));
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -22,6 +22,7 @@ import { DreyvMark } from "@/components/brand/dreyv-mark";
 import { DreyvLogoLight } from "@/components/brand/dreyv-logo-light";
 import { motion, AnimatePresence } from "framer-motion";
 import { marketingPrimaryCta } from "@/components/home/marketing-styles";
+import { sanitizeRedirect } from '@/lib/utils';
 
 const LOGO_DEV_TOKEN = "pk_DFEjHHL4QteaMOzcFuSlwg";
 
@@ -414,7 +415,7 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = sanitizeRedirect(searchParams.get('redirect'));
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+
+export function sanitizeRedirect(url: string | null | undefined): string {
+  if (!url) return "/app";
+
+  try {
+    // Only allow absolute paths starting with a single slash,
+    // explicitly disallowing protocol-relative URLs (//) and backslashes (\)
+    if (url.startsWith("/") && !url.startsWith("//") && !url.startsWith("/\\")) {
+      return url;
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  return "/app";
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Open redirect allowing attackers to redirect users to malicious domains after authentication via the `redirect` and `next` query parameters.
🎯 Impact: Attackers can construct malicious URLs that appear to be legitimate Keystone/Dreyv login links, but redirect the user to a phishing site after successful authentication.
🔧 Fix: Implemented `sanitizeRedirect` utility to ensure redirect URLs are strictly relative paths on the same origin (starting with `/`, rejecting protocol-relative `//` or `/\`). Applied it to the auth page and OAuth callback route.
✅ Verification: Tested locally, checked for compilation errors, and verified against tests. Open redirect attempts (e.g. `?redirect=//evil.com`) are now intercepted and fallback securely to `/app`.

---
*PR created automatically by Jules for task [5055893903564392443](https://jules.google.com/task/5055893903564392443) started by @programmeradu*