### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in Next.js Authentication Callbacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-01 - Open Redirect via Unsanitized Next/Redirect Query Parameters
+**Vulnerability:** The application was using user-supplied URL parameters (`searchParams.get('redirect')` and `searchParams.get('next')`) directly in redirection logic (`window.location.href` and `NextResponse.redirect()`) without validating that the target was a local relative path.
+**Learning:** Next.js and frontend applications often use `redirect` or `next` parameters for post-login redirection. If an attacker crafts a malicious URL (e.g., `?redirect=//evil.com` or `?redirect=https://evil.com`), it can lead to an Open Redirect vulnerability, tricking users into visiting malicious sites.
+**Prevention:** Always sanitize user-provided redirect URLs by strictly validating that they start with a single `/` and reject `//` or `/\` protocol-relative paths. Centralize this validation in a utility like `sanitizeRedirect` and enforce its use across the application.

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -11,11 +11,12 @@ import { createSupabaseServerClient } from '@/lib/supabase';
 import { db } from '@/db';
 import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { sanitizeRedirect } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
     const { searchParams, origin } = new URL(request.url);
     const code = searchParams.get('code');
-    const next = searchParams.get('next') ?? '/app';
+    const next = sanitizeRedirect(searchParams.get('next'));
 
     if (!code) {
         // No code — redirect to auth page with error

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -16,6 +16,7 @@ import {
     RefreshCw,
     Lock,
 } from "lucide-react";
+import { sanitizeRedirect } from "@/lib/utils";
 
 import { Logo, Sparkles } from "@/components/icons";
 import { DreyvMark } from "@/components/brand/dreyv-mark";
@@ -414,7 +415,7 @@ function AuthPageContent() {
     }, [searchParams, addLog]);
 
     // Determine where to go after auth (supports ?redirect= param from middleware)
-    const postAuthRedirect = searchParams.get('redirect') || '/app';
+    const postAuthRedirect = sanitizeRedirect(searchParams.get('redirect'));
 
     // Handle OAuth completion: exchange Neon Auth session for local JWT
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Sanitizes a redirect URL to ensure it is a relative path.
+ * Prevents Open Redirect vulnerabilities by rejecting absolute URLs and protocol-relative URLs.
+ */
+export function sanitizeRedirect(url: string | null | undefined, defaultUrl = '/app'): string {
+  if (!url || typeof url !== 'string') return defaultUrl;
+
+  // Ensure the URL starts with a single slash, not a double slash or a backslash
+  if (url.startsWith('/') && !url.startsWith('//') && !url.startsWith('/\\')) {
+    return url;
+  }
+
+  return defaultUrl;
+}


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: The application was taking user-supplied query parameters (`searchParams.get('redirect')` and `searchParams.get('next')`) and passing them directly into routing/redirection functions (`window.location.href` and `NextResponse.redirect()`) without validating that the target is a local, relative path. This allowed for Open Redirect attacks where an attacker could craft a URL like `?redirect=//evil.com` or `?redirect=https://evil.com`.

🎯 **Impact**: Attackers could distribute malicious links that appear to originate from the trusted application domain but redirect users to phishing sites or malware after a successful authentication flow, leading to credential theft or compromised trust.

🔧 **Fix**: 
1. Centralized a new validation utility `sanitizeRedirect` in `src/lib/utils.ts`.
2. Updated `src/app/auth/page.tsx` to sanitize the `postAuthRedirect` variable before assignment.
3. Updated `src/app/api/auth/callback/route.ts` to sanitize the `next` variable before assignment.
4. Logged the pattern and prevention strategy to `.jules/sentinel.md`.

✅ **Verification**: Run `bun test`, `bun x tsc --noEmit --project tsconfig.json`, `bun run lint`, and `bun run build`. All checks completed successfully.

---
*PR created automatically by Jules for task [13562944647658248872](https://jules.google.com/task/13562944647658248872) started by @programmeradu*